### PR TITLE
A11Y Improvements -- Render buttons as buttons

### DIFF
--- a/app/renderer/controls/Button.tsx
+++ b/app/renderer/controls/Button.tsx
@@ -26,6 +26,10 @@ const StyledButton = styled.button<StyledButtonProps>`
   text-overflow: ellipsis;
   font-size: 0.9em;
 
+  &:disabled {
+    cursor: unset;
+  }
+
   &:focus-visible {
     outline: 4px solid
       ${(p) => Color(p.theme.buttonPrimaryBg).alpha(0.5).toString()};
@@ -75,14 +79,14 @@ type ButtonProps = {
   children?: React.ReactNode;
   onClick?: () => void;
   loading?: boolean;
-  disabled?: boolean;
+  isDisabled?: boolean;
 };
 
 const Button = ({
   children,
   onClick,
   loading = false,
-  disabled = false,
+  isDisabled = false,
 }: ButtonProps) => {
   const theme = useTheme();
   const hoverColor = Color(theme.buttonPrimaryBg).lighten(0.05).hsl().string();
@@ -91,16 +95,16 @@ const Button = ({
     <StyledButton
       hoverBackgroundcolor={hoverColor}
       activeBackgroundColor={activeColor}
+      disabled={isDisabled}
       onClick={() => {
-        if (!loading && !disabled && onClick) {
+        if (!loading && !isDisabled && onClick) {
           onClick();
         }
       }}
       isLoading={loading}
-      isDisabled={disabled}
     >
       {children}
-      <StyledLoader isLoading={loading} isDisabled={disabled}>
+      <StyledLoader isLoading={loading} isDisabled={isDisabled}>
         <BounceLoader
           loading={loading}
           size={20}

--- a/app/renderer/controls/Button.tsx
+++ b/app/renderer/controls/Button.tsx
@@ -26,6 +26,10 @@ const StyledButton = styled.button<StyledButtonProps>`
   text-overflow: ellipsis;
   font-size: 0.9em;
 
+  &:focus-visible {
+    outline: ${(p) =>
+      `4px solid ${Color(p.theme.buttonPrimaryBg).alpha(0.5).toString()};`}
+
   ${(p) =>
     !p.isLoading &&
     !p.isDisabled &&

--- a/app/renderer/controls/Button.tsx
+++ b/app/renderer/controls/Button.tsx
@@ -9,7 +9,7 @@ type StyledButtonProps = {
   isDisabled?: boolean;
 };
 
-const StyledButton = styled.span<StyledButtonProps>`
+const StyledButton = styled.button<StyledButtonProps>`
   height: 30px;
   position: relative;
   line-height: 30px;
@@ -19,6 +19,7 @@ const StyledButton = styled.span<StyledButtonProps>`
   background-color: ${(p) => p.theme.buttonPrimaryBg};
   color: ${(p) => p.theme.buttonPrimaryText};
   border-radius: 10px;
+  border: none;
   text-align: center;
   white-space: nowrap;
   overflow: hidden;

--- a/app/renderer/controls/Button.tsx
+++ b/app/renderer/controls/Button.tsx
@@ -26,10 +26,6 @@ const StyledButton = styled.button<StyledButtonProps>`
   text-overflow: ellipsis;
   font-size: 0.9em;
 
-  &:disabled {
-    cursor: unset;
-  }
-
   &:focus-visible {
     outline: 4px solid
       ${(p) => Color(p.theme.buttonPrimaryBg).alpha(0.5).toString()};
@@ -37,7 +33,7 @@ const StyledButton = styled.button<StyledButtonProps>`
 
   ${(p) =>
     !p.isLoading &&
-    !p.isDisabled &&
+    !p.disabled &&
     css`
       cursor: pointer;
       &:hover {

--- a/app/renderer/controls/Button.tsx
+++ b/app/renderer/controls/Button.tsx
@@ -27,8 +27,9 @@ const StyledButton = styled.button<StyledButtonProps>`
   font-size: 0.9em;
 
   &:focus-visible {
-    outline: ${(p) =>
-      `4px solid ${Color(p.theme.buttonPrimaryBg).alpha(0.5).toString()};`}
+    outline: 4px solid
+      ${(p) => Color(p.theme.buttonPrimaryBg).alpha(0.5).toString()};
+  }
 
   ${(p) =>
     !p.isLoading &&

--- a/app/renderer/modals/GenerateBookModal.tsx
+++ b/app/renderer/modals/GenerateBookModal.tsx
@@ -73,7 +73,7 @@ const GenerateBookModal = (props: ModalProps) => {
           </CheckboxDiv>
         </StyledModalContent>
         <StyledButtonDiv>
-          <Button loading={isBuildingPdf} disabled={!pdfPlatformToggleValue}>
+          <Button loading={isBuildingPdf} isDisabled={!pdfPlatformToggleValue}>
             Generate
           </Button>
         </StyledButtonDiv>

--- a/app/renderer/modals/GenerateBookModal.tsx
+++ b/app/renderer/modals/GenerateBookModal.tsx
@@ -1,10 +1,10 @@
 import { useRef, useState } from 'react';
 import styled from 'styled-components';
+import { buildBookPdf } from 'renderer/utils/buildPdf';
+import { useOnBookPdfGenerated, useToggle } from 'renderer/hooks';
 import Modal from './Modal';
 import type { ModalProps } from './Modal';
 import { Button, Checkbox } from '../controls';
-import { buildBookPdf } from 'renderer/utils/buildPdf';
-import { useOnBookPdfGenerated, useToggle } from 'renderer/hooks';
 
 const StyledModalContent = styled.div`
   display: flex;
@@ -66,20 +66,14 @@ const GenerateBookModal = (props: ModalProps) => {
           <ModalTitle>Output Platforms</ModalTitle>
           <CheckboxDiv>
             <Checkbox
-              label={'PDF'}
+              label="PDF"
               checked={pdfPlatformToggleValue}
               onChange={togglePdfPlatformToggleValue}
             />
           </CheckboxDiv>
         </StyledModalContent>
         <StyledButtonDiv>
-          <Button
-            loading={isBuildingPdf}
-            onClick={() => {
-              formRef.current?.requestSubmit();
-            }}
-            disabled={!pdfPlatformToggleValue}
-          >
+          <Button loading={isBuildingPdf} disabled={!pdfPlatformToggleValue}>
             Generate
           </Button>
         </StyledButtonDiv>

--- a/app/renderer/modals/NewBookModal.tsx
+++ b/app/renderer/modals/NewBookModal.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import React, { useRef } from 'react';
 import styled from 'styled-components';
 import Modal from './Modal';
 import type { ModalProps } from './Modal';
@@ -20,6 +20,7 @@ const NewBookModal = (props: ModalProps) => {
   const formRef = useRef<HTMLFormElement>(null);
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
     const target = e.target as typeof e.target & {
       book: { value: string };
       author: { value: string };
@@ -30,7 +31,8 @@ const NewBookModal = (props: ModalProps) => {
       authorName: target.author.value,
       seriesName: target.series.value,
     });
-    onRequestClose();
+
+    return onRequestClose();
   };
   return (
     <Modal {...props}>

--- a/app/renderer/modals/NewBookModal.tsx
+++ b/app/renderer/modals/NewBookModal.tsx
@@ -57,13 +57,7 @@ const NewBookModal = (props: ModalProps) => {
             label="Series Name"
           />
           <div />
-          <Button
-            onClick={() => {
-              formRef.current?.requestSubmit();
-            }}
-          >
-            Create
-          </Button>
+          <Button>Create</Button>
         </StyledModalContent>
       </form>
     </Modal>

--- a/app/renderer/modals/NewBookModal.tsx
+++ b/app/renderer/modals/NewBookModal.tsx
@@ -57,7 +57,7 @@ const NewBookModal = (props: ModalProps) => {
             label="Series Name"
           />
           <div />
-          <Button isDisabled>Create</Button>
+          <Button>Create</Button>
         </StyledModalContent>
       </form>
     </Modal>

--- a/app/renderer/modals/NewBookModal.tsx
+++ b/app/renderer/modals/NewBookModal.tsx
@@ -57,7 +57,7 @@ const NewBookModal = (props: ModalProps) => {
             label="Series Name"
           />
           <div />
-          <Button>Create</Button>
+          <Button isDisabled>Create</Button>
         </StyledModalContent>
       </form>
     </Modal>


### PR DESCRIPTION
Per #148, I have been playing with the application tonight and the first thing that leapt out to me was that the form on the "New Project" modal was not able to be submitted by keyboard. The root cause of this that this PR fixes is rendering buttons as buttons rather than a div/span. 

This can cause multiple accessibility challenges both to keyboard navigation and control and also screen reader identification. Forms throughout the application are now able to be submitted by keyboard so long as they utilize a real `<form>` element and an `onSubmit` property. 